### PR TITLE
Bump up version of node for chromium

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         sudo mkdir -p /app/print
         sudo cp target/pdfshot.js /app
         cd /app
-        sudo -E npm install puppeteer@13.1.1 express@4.17.2
+        sudo -E npm install puppeteer@19.4.1 express@4.18.2
         sudo -E node pdfshot.js --no-sandbox &
         cd $GITHUB_WORKSPACE
         sleep 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,4 +39,4 @@ jobs:
         sleep 10
         curl -fsLJO "localhost:$PDFSHOT_PORT/print.pdf?target=https%3A%2F%2Fexample.com"
         pgrep node | sudo xargs kill
-        [[ "`file print.pdf`" == "print.pdf: PDF document, version 1.4" ]]
+        [[ "$(file print.pdf)" == "print.pdf: PDF document, version 1.4, 1 pages" ]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM clojure:openjdk-11-lein-buster AS builder
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_19.x | bash - && \
     apt-get install -y nodejs
 WORKDIR /build/
 COPY project.clj /build/
@@ -32,7 +32,7 @@ RUN apk update && \
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
 WORKDIR /app
-RUN npm install puppeteer@13.1.1 express@4.17.2 && \
+RUN npm install puppeteer@19.4.1 express@4.18.2 && \
     mkdir /app/print
 
 RUN addgroup -S pptruser && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY project.clj /build/
 COPY src /build/src/
 RUN lein cljsbuild once
 
-FROM node:16.13.1-alpine3.13
+FROM node:19.3.0-alpine3.16
 
 RUN apk update && \
     apk upgrade && \

--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,6 @@
                                    :output-to "target/pdfshot.js"
                                    :target :nodejs
                                    :optimizations :simple
-                                   :npm-deps {"puppeteer" "13.1.1"
-                                              "express" "4.17.2"}
+                                   :npm-deps {"puppeteer" "19.4.1"
+                                              "express" "4.18.2"}
                                    :install-deps true}}]})


### PR DESCRIPTION
Bump up version of node for chromium.
It is destructive update, because it affect to appearance a bit on output pdf.